### PR TITLE
i18N:  add a support for multi-byte characters.

### DIFF
--- a/GcmSharp/GcmSharp/GcmManager.cs
+++ b/GcmSharp/GcmSharp/GcmManager.cs
@@ -259,7 +259,7 @@ namespace GcmSharp
             HttpWebResponse httpResponse;
             string responseData;
             SetupRequest(url);
-            request.ContentLength = data.Length;
+            request.ContentLength = Encoding.UTF8.GetByteCount(data);
 
             using (var dataStream = new StreamWriter(request.GetRequestStream()))
             {


### PR DESCRIPTION
The Content-Length header should be the length of the response body in octets (8-bit bytes), and not the number of characters.
